### PR TITLE
Fix #1: add demo page configuration

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "hacker_news",
   "name": "Hacker News",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Display the top Hacker News story title and score on your board.",
   "author": "FiestaBoard Team",
   "icon": "newspaper",
@@ -93,5 +93,25 @@
       "primary": true
     }
   ],
+  "demo": {
+    "name": "Hacker News Demo",
+    "device_type": "flagship",
+    "template": [
+      "HACKER NEWS",
+      "{{title}}",
+      "SCORE {{score}}  BY {{author}}",
+      "COMMENTS {{comments}}",
+      "{white}{white}{white}{white}{white}{white}{white}{white}{white}{white}",
+      "{white}{white}{white}{white}{white}{white}{white}{white}{white}{white}"
+    ],
+    "line_metadata": [
+      {"alignment": "left", "wrap": false},
+      {"alignment": "left", "wrap": false},
+      {"alignment": "left", "wrap": false},
+      {"alignment": "left", "wrap": false},
+      {"alignment": "left", "wrap": false},
+      {"alignment": "left", "wrap": false}
+    ]
+  },
   "api_docs": "https://github.com/HackerNews/API"
 }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -101,6 +101,17 @@ class TestHackerNewsPlugin:
         for field in ("id", "name", "version"):
             assert field in m
 
+    def test_manifest_includes_demo_page(self):
+        manifest_path = Path(__file__).parent.parent / "manifest.json"
+        with open(manifest_path) as f:
+            m = json.load(f)
+        assert "demo" in m
+        assert isinstance(m["demo"], dict)
+        assert m["demo"].get("name") == "Hacker News Demo"
+        assert m["demo"].get("device_type") == "flagship"
+        assert isinstance(m["demo"].get("template"), list)
+        assert len(m["demo"].get("line_metadata", [])) == len(m["demo"].get("template", []))
+
     @patch("plugins.hacker_news.requests.get")
     def test_fetch_data_success(self, mock_get, configured_plugin):
         ids_response = Mock()


### PR DESCRIPTION
This PR fixes issue #1 by adding a `demo` definition to `manifest.json` so the Hacker News plugin exposes a demo page button in settings. It also includes a manifest test to ensure the demo configuration is present.