### PR TITLE
Add Note demo page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "hacker_news",
   "name": "Hacker News",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Display the top Hacker News story title and score on your board.",
   "author": "FiestaBoard Team",
   "icon": "newspaper",
@@ -94,24 +94,65 @@
     }
   ],
   "demo": {
-    "name": "Hacker News Demo",
-    "device_type": "flagship",
-    "template": [
-      "HACKER NEWS",
-      "{{title}}",
-      "SCORE {{score}}  BY {{author}}",
-      "COMMENTS {{comments}}",
-      "{white}{white}{white}{white}{white}{white}{white}{white}{white}{white}",
-      "{white}{white}{white}{white}{white}{white}{white}{white}{white}{white}"
-    ],
-    "line_metadata": [
-      {"alignment": "left", "wrap": false},
-      {"alignment": "left", "wrap": false},
-      {"alignment": "left", "wrap": false},
-      {"alignment": "left", "wrap": false},
-      {"alignment": "left", "wrap": false},
-      {"alignment": "left", "wrap": false}
-    ]
+    "flagship": {
+      "name": "Hacker News Demo",
+      "template": [
+        "HACKER NEWS",
+        "{{title}}",
+        "SCORE {{score}}  BY {{author}}",
+        "COMMENTS {{comments}}",
+        "{white}{white}{white}{white}{white}{white}{white}{white}{white}{white}",
+        "{white}{white}{white}{white}{white}{white}{white}{white}{white}{white}"
+      ],
+      "line_metadata": [
+        {
+          "alignment": "left",
+          "wrap": false
+        },
+        {
+          "alignment": "left",
+          "wrap": false
+        },
+        {
+          "alignment": "left",
+          "wrap": false
+        },
+        {
+          "alignment": "left",
+          "wrap": false
+        },
+        {
+          "alignment": "left",
+          "wrap": false
+        },
+        {
+          "alignment": "left",
+          "wrap": false
+        }
+      ]
+    },
+    "note": {
+      "name": "Hacker News (Note)",
+      "template": [
+        "HACKER NEWS",
+        "{{title}}",
+        "SCORE {{score}}"
+      ],
+      "line_metadata": [
+        {
+          "alignment": "left",
+          "wrap": false
+        },
+        {
+          "alignment": "left",
+          "wrap": true
+        },
+        {
+          "alignment": "left",
+          "wrap": false
+        }
+      ]
+    }
   },
   "api_docs": "https://github.com/HackerNews/API"
 }


### PR DESCRIPTION
## Summary

- Adds a Note (15×3) demo page to the plugin manifest
- Converts `demo` from the old flat single-entry format to the keyed `{"flagship": {...}, "note": {...}}` format
- Bumps patch version

## Test plan

- [ ] Confirm "Create Demo Page" button creates a Note page when the board is configured as a Note
- [ ] Confirm the flagship demo page still works for Flagship boards

Closes Fiestaboard/FiestaBoard#702

🤖 Generated with [Claude Code](https://claude.com/claude-code)