### PR TITLE
fix: stop truncating exposed string variables

### DIFF
--- a/plugins/hacker_news/__init__.py
+++ b/plugins/hacker_news/__init__.py
@@ -49,10 +49,10 @@ class HackerNewsPlugin(PluginBase):
             story_response.raise_for_status()
             story = story_response.json()
 
-            title = str(story.get("title", ""))[:22]
+            title = str(story.get("title", ""))
             score = int(story.get("score", 0))
             comments = int(story.get("descendants", 0))
-            author = str(story.get("by", "unknown"))[:15]
+            author = str(story.get("by", "unknown"))
 
             return PluginResult(
                 available=True,


### PR DESCRIPTION
## Summary
Removed `[:22]` slice on `title` and `[:15]` slice on `author` in `plugins/hacker_news/__init__.py`. Exposed template variables in `PluginResult.data` should be returned in full; truncation belongs in templates (which can use `.center(22)` / `.ljust(22)` etc.).

## Test plan
- [x] Existing tests still pass (no assertions depended on the truncated lengths).